### PR TITLE
Add another target to nbuild.targets

### DIFF
--- a/docs/02-nbuild.targets.md
+++ b/docs/02-nbuild.targets.md
@@ -2,7 +2,6 @@
 
 - Follow [documentation](https://naz-hage.github.io/ntools/) to install `ntools`
 - Add [nbuild.targets](https://naz-hage.github.io/ntools/setup/#nbuildtargets) file
-- Add your own targets (In [this example](../nbuild.targets#L56-L61), a target was added to build and test without changing the tag)
 - Open a VS command Prompt for Visual studio
    - Change to project working directory
    -  Run
@@ -11,3 +10,10 @@ nb staging
 nb production
 ```
 - Ensure that ntools runs pass
+
+## Add more targets
+- Check [this example](../nbuild.targets#L56-L61): a target was added to build and test without changing the tag)
+- This will create the command below
+```
+nb build_test
+```

--- a/docs/02-nbuild.targets.md
+++ b/docs/02-nbuild.targets.md
@@ -1,7 +1,8 @@
 # Add nbuild.targets
 
 - Follow [documentation](https://naz-hage.github.io/ntools/) to install `ntools`
-- Add [nbuild.targets](https://naz-hage.github.io/ntools/setup/#nbuildtargets) file 
+- Add [nbuild.targets](https://naz-hage.github.io/ntools/setup/#nbuildtargets) file
+- Add your own targets (In [this example](../nbuild.targets#L56-L61), a target was added to build and test without changing the tag)
 - Open a VS command Prompt for Visual studio
    - Change to project working directory
    -  Run

--- a/nbuild.targets
+++ b/nbuild.targets
@@ -53,4 +53,11 @@
         <Message Text="==> DONE"/>
     </Target>
 
+  <!-- Example target to build and test without changing the tag -->
+    <Target Name="BUILD_TEST" DependsOnTargets="
+        CLEAN;
+        SOLUTION;
+        TEST">
+    </Target>
+
 </Project>


### PR DESCRIPTION
This PR adds a custom target to `nbuild.targets` and documents the example.